### PR TITLE
Adding HasReason method to Nacelle Health.

### DIFF
--- a/health.go
+++ b/health.go
@@ -14,6 +14,7 @@ type (
 		LastChange() time.Duration
 		AddReason(key interface{}) error
 		RemoveReason(key interface{}) error
+		HasReason(key interface{}) bool
 	}
 
 	health struct {
@@ -93,4 +94,15 @@ func (h *health) RemoveReason(key interface{}) error {
 	}
 
 	return nil
+}
+
+func (h *health) HasReason(key interface{}) bool {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	if _, ok := h.reasons[key]; ok {
+		return true
+	}
+
+	return false
 }

--- a/health_test.go
+++ b/health_test.go
@@ -20,11 +20,18 @@ func (s *HealthSuite) TestReasons(t sweet.T) {
 
 	clock.Advance(time.Hour)
 	Expect(health.AddReason("foo")).To(BeNil())
+	Expect(health.HasReason("foo")).To(BeTrue())
 	clock.Advance(time.Minute)
 	Expect(health.AddReason("bar")).To(BeNil())
+	Expect(health.HasReason("foo")).To(BeTrue())
+	Expect(health.HasReason("bar")).To(BeTrue())
 	clock.Advance(time.Minute)
 	Expect(health.AddReason("baz")).To(BeNil())
+	Expect(health.HasReason("foo")).To(BeTrue())
+	Expect(health.HasReason("bar")).To(BeTrue())
+	Expect(health.HasReason("baz")).To(BeTrue())
 	Expect(health.RemoveReason("bar")).To(BeNil())
+	Expect(health.HasReason("bar")).To(BeFalse())
 
 	Expect(health.Reasons()).To(ConsistOf([]Reason{
 		Reason{Key: "foo", Added: now.Add(time.Hour)},
@@ -42,21 +49,26 @@ func (s *HealthSuite) TestLastChangedTime(t sweet.T) {
 	// Changed
 	clock.Advance(time.Hour)
 	Expect(health.AddReason("foo")).To(BeNil())
+	Expect(health.HasReason("foo")).To(BeTrue())
+
 	clock.Advance(time.Minute * 2)
 	Expect(health.LastChange()).To(Equal(time.Minute * 2))
 
 	// No change
 	Expect(health.AddReason("bar")).To(BeNil())
+	Expect(health.HasReason("bar")).To(BeTrue())
 	clock.Advance(time.Minute * 4)
 	Expect(health.LastChange()).To(Equal(time.Minute * 6))
 
 	// No change
 	Expect(health.RemoveReason("foo")).To(BeNil())
+	Expect(health.HasReason("foo")).To(BeFalse())
 	clock.Advance(time.Minute * 2)
 	Expect(health.LastChange()).To(Equal(time.Minute * 8))
 
 	// Changed
 	Expect(health.RemoveReason("bar")).To(BeNil())
+	Expect(health.HasReason("bar")).To(BeFalse())
 	Expect(health.LastChange()).To(Equal(time.Minute * 0))
 }
 


### PR DESCRIPTION
Adding the ability to check for a specific health reason using nacelle Health. This allows a check utilizing the built in mutex to help avoid any possible race conditions.