### PR TITLE
Configure service loggers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/efritz/watchdog v0.0.0-20181228234521-84cf7cb74656
 	github.com/go-nacelle/config v1.0.0
 	github.com/go-nacelle/log v1.0.0
-	github.com/go-nacelle/service v1.0.0
+	github.com/go-nacelle/service v1.0.1
 	github.com/onsi/gomega v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3st
 github.com/aphistic/sweet-junit v0.0.0-20171005212431-6b78f7014f7c/go.mod h1:+rEpaBMG7nKCTS5rjybTdJwqNG0ayGoPUm+sCPBgi9Y=
 github.com/aphistic/sweet-junit v0.0.0-20190314030539-8d7e248096c2 h1:qDCG/a4+mCcRqj+QHTc1RNncar6rpg0oGz9ynH4IRME=
 github.com/aphistic/sweet-junit v0.0.0-20190314030539-8d7e248096c2/go.mod h1:+eL69RqmiKF2Jm3poefxF/ZyVNGXFdSsPq3ScBFtX9s=
+github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -49,9 +50,12 @@ github.com/go-nacelle/log v1.0.0 h1:1PdYEw6a5GnRQZdWqDsJmXyARbKru3XC2+Rzxo5GbnU=
 github.com/go-nacelle/log v1.0.0/go.mod h1:2bN7vfOSvHTzHWxiTYz+F8/MvustIt/HmARQt67gXz4=
 github.com/go-nacelle/service v1.0.0 h1:isr7QDxRxGxaAoAmXupOEGf6D7v9wX6odmPRnPyh1f8=
 github.com/go-nacelle/service v1.0.0/go.mod h1:JHLisFWKRjLlGdg17Jrm+rtUEXdDnPtT7gZcrRhGrMA=
+github.com/go-nacelle/service v1.0.1 h1:SRrEpgTayi/k5Bp4ImQkdrGpb75mtfmv8JpATZOZf7c=
+github.com/go-nacelle/service v1.0.1/go.mod h1:Ov7RTme6wUkGUj2qxllLtVOwslrVsg3k6nGHXk9HNWE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -61,6 +65,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -106,6 +111,8 @@ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/Le
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56 h1:ZpKuNIejY8P0ExLOVyKhb0WsgG8UdvHXe6TWjY7eL6k=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
+golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -114,6 +121,9 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
+golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -127,6 +137,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190429094411-2cc0cad0ac78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
+golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -134,6 +146,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190128232029-0a99049195af/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190428024724-550556f78a90/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/initializer_meta.go
+++ b/initializer_meta.go
@@ -12,7 +12,7 @@ type (
 	InitializerMeta struct {
 		Initializer
 		name            string
-		loggingFields   log.LogFields
+		logFields       log.LogFields
 		initTimeout     time.Duration
 		finalizeTimeout time.Duration
 	}
@@ -33,9 +33,9 @@ func (m *InitializerMeta) Name() string {
 	return m.name
 }
 
-// LoggingFields returns logging fields registered to this initializer.
-func (m *InitializerMeta) LoggingFields() log.LogFields {
-	return m.loggingFields
+// LogFields returns logging fields registered to this initializer.
+func (m *InitializerMeta) LogFields() log.LogFields {
+	return m.logFields
 }
 
 // InitTimeout returns the maximum timeout allowed for a call to

--- a/initializer_meta.go
+++ b/initializer_meta.go
@@ -1,6 +1,10 @@
 package process
 
-import "time"
+import (
+	"time"
+
+	"github.com/go-nacelle/log"
+)
 
 type (
 	// InitializerMeta wraps an initializer with some package
@@ -8,6 +12,7 @@ type (
 	InitializerMeta struct {
 		Initializer
 		name            string
+		loggingFields   log.LogFields
 		initTimeout     time.Duration
 		finalizeTimeout time.Duration
 	}
@@ -26,6 +31,11 @@ func (m *InitializerMeta) Name() string {
 	}
 
 	return m.name
+}
+
+// LoggingFields returns logging fields registered to this initializer.
+func (m *InitializerMeta) LoggingFields() log.LogFields {
+	return m.loggingFields
 }
 
 // InitTimeout returns the maximum timeout allowed for a call to

--- a/initializer_options.go
+++ b/initializer_options.go
@@ -15,10 +15,10 @@ func WithInitializerName(name string) InitializerConfigFunc {
 	return func(meta *InitializerMeta) { meta.name = name }
 }
 
-// WithInitializerLoggingFields sets additional fields sent with every log message
+// WithInitializerLogFields sets additional fields sent with every log message
 // from this initializer.
-func WithInitializerLoggingFields(fields log.LogFields) InitializerConfigFunc {
-	return func(meta *InitializerMeta) { meta.loggingFields = fields }
+func WithInitializerLogFields(fields log.LogFields) InitializerConfigFunc {
+	return func(meta *InitializerMeta) { meta.logFields = fields }
 }
 
 // WithInitializerTimeout sets the time limit for the initializer.

--- a/initializer_options.go
+++ b/initializer_options.go
@@ -1,6 +1,10 @@
 package process
 
-import "time"
+import (
+	"time"
+
+	"github.com/go-nacelle/log"
+)
 
 // InitializerConfigFunc is a function used to append additional
 // metadata to an initializer during registration.
@@ -9,6 +13,12 @@ type InitializerConfigFunc func(*InitializerMeta)
 // WithInitializerName assigns a name to an initializer, visible in logs.
 func WithInitializerName(name string) InitializerConfigFunc {
 	return func(meta *InitializerMeta) { meta.name = name }
+}
+
+// WithInitializerLoggingFields sets additional fields sent with every log message
+// from this initializer.
+func WithInitializerLoggingFields(fields log.LogFields) InitializerConfigFunc {
+	return func(meta *InitializerMeta) { meta.loggingFields = fields }
 }
 
 // WithInitializerTimeout sets the time limit for the initializer.

--- a/parallel_initializer.go
+++ b/parallel_initializer.go
@@ -101,7 +101,7 @@ func (pi *ParallelInitializer) Finalize() error {
 func (pi *ParallelInitializer) inject(initializer namedInjectable) error {
 	pi.Logger.Info("Injecting services into %s", initializer.Name())
 
-	if err := inject(pi.Services, pi.Logger, initializer); err != nil {
+	if err := inject(initializer, pi.Services, pi.Logger); err != nil {
 		return fmt.Errorf(
 			"failed to inject services into %s (%s)",
 			initializer.Name(),

--- a/parallel_initializer.go
+++ b/parallel_initializer.go
@@ -53,7 +53,7 @@ func (i *ParallelInitializer) RegisterInitializer(
 // Init runs Init on all registered initializers concurrently.
 func (pi *ParallelInitializer) Init(config config.Config) error {
 	for _, initializer := range pi.initializers {
-		if err := pi.injectAll(initializer); err != nil {
+		if err := pi.inject(initializer); err != nil {
 			return errMetaSet{
 				errMeta{err: err, source: initializer},
 			}
@@ -98,10 +98,10 @@ func (pi *ParallelInitializer) Finalize() error {
 	return nil
 }
 
-func (pi *ParallelInitializer) injectAll(initializer namedFinalizer) error {
+func (pi *ParallelInitializer) inject(initializer namedInjectable) error {
 	pi.Logger.Info("Injecting services into %s", initializer.Name())
 
-	if err := pi.Services.Inject(initializer.Wrapped()); err != nil {
+	if err := inject(pi.Services, pi.Logger, initializer); err != nil {
 		return fmt.Errorf(
 			"failed to inject services into %s (%s)",
 			initializer.Name(),

--- a/parallel_initializer.go
+++ b/parallel_initializer.go
@@ -99,7 +99,7 @@ func (pi *ParallelInitializer) Finalize() error {
 }
 
 func (pi *ParallelInitializer) inject(initializer namedInjectable) error {
-	pi.Logger.Info("Injecting services into %s", initializer.Name())
+	pi.Logger.WithFields(initializer.LogFields()).Info("Injecting services into %s", initializer.Name())
 
 	if err := inject(initializer, pi.Services, pi.Logger); err != nil {
 		return fmt.Errorf(
@@ -177,7 +177,7 @@ func (pi *ParallelInitializer) initWithTimeout(initializer namedInitializer, con
 }
 
 func (pi *ParallelInitializer) init(initializer namedInitializer, config config.Config) error {
-	pi.Logger.Info("Initializing %s", initializer.Name())
+	pi.Logger.WithFields(initializer.LogFields()).Info("Initializing %s", initializer.Name())
 
 	if err := initializer.Init(config); err != nil {
 		return fmt.Errorf(
@@ -187,7 +187,7 @@ func (pi *ParallelInitializer) init(initializer namedInitializer, config config.
 		)
 	}
 
-	pi.Logger.Info("Initialized %s", initializer.Name())
+	pi.Logger.WithFields(initializer.LogFields()).Info("Initialized %s", initializer.Name())
 	return nil
 }
 
@@ -211,7 +211,7 @@ func (pi *ParallelInitializer) finalize(initializer namedFinalizer) error {
 		return nil
 	}
 
-	pi.Logger.Info("Finalizing %s", initializer.Name())
+	pi.Logger.WithFields(initializer.LogFields()).Info("Finalizing %s", initializer.Name())
 
 	if err := finalizer.Finalize(); err != nil {
 		return fmt.Errorf(
@@ -221,7 +221,7 @@ func (pi *ParallelInitializer) finalize(initializer namedFinalizer) error {
 		)
 	}
 
-	pi.Logger.Info("Finalized %s", initializer.Name())
+	pi.Logger.WithFields(initializer.LogFields()).Info("Finalized %s", initializer.Name())
 	return nil
 }
 

--- a/process_meta.go
+++ b/process_meta.go
@@ -13,7 +13,7 @@ type (
 	ProcessMeta struct {
 		Process
 		name            string
-		loggingFields   log.LogFields
+		logFields       log.LogFields
 		priority        int
 		silentExit      bool
 		once            *sync.Once
@@ -41,9 +41,9 @@ func (m *ProcessMeta) Name() string {
 	return m.name
 }
 
-// LoggingFields returns logging fields registered to this process.
-func (m *ProcessMeta) LoggingFields() log.LogFields {
-	return m.loggingFields
+// Logields returns logging fields registered to this process.
+func (m *ProcessMeta) LogFields() log.LogFields {
+	return m.logFields
 }
 
 // InitTimeout returns the maximum timeout allowed for a call to

--- a/process_meta.go
+++ b/process_meta.go
@@ -3,6 +3,8 @@ package process
 import (
 	"sync"
 	"time"
+
+	"github.com/go-nacelle/log"
 )
 
 type (
@@ -11,6 +13,7 @@ type (
 	ProcessMeta struct {
 		Process
 		name            string
+		loggingFields   log.LogFields
 		priority        int
 		silentExit      bool
 		once            *sync.Once
@@ -36,6 +39,11 @@ func (m *ProcessMeta) Name() string {
 	}
 
 	return m.name
+}
+
+// LoggingFields returns logging fields registered to this process.
+func (m *ProcessMeta) LoggingFields() log.LogFields {
+	return m.loggingFields
 }
 
 // InitTimeout returns the maximum timeout allowed for a call to

--- a/process_options.go
+++ b/process_options.go
@@ -15,10 +15,10 @@ func WithProcessName(name string) ProcessConfigFunc {
 	return func(meta *ProcessMeta) { meta.name = name }
 }
 
-// WithProcessLoggingFields sets additional fields sent with every log message
+// WithProcessLogFields sets additional fields sent with every log message
 // from this process.
-func WithProcessLoggingFields(fields log.LogFields) ProcessConfigFunc {
-	return func(meta *ProcessMeta) { meta.loggingFields = fields }
+func WithProcessLogFields(fields log.LogFields) ProcessConfigFunc {
+	return func(meta *ProcessMeta) { meta.logFields = fields }
 }
 
 // WithPriority assigns a priority to a process. A process with a lower-valued

--- a/process_options.go
+++ b/process_options.go
@@ -1,6 +1,10 @@
 package process
 
-import "time"
+import (
+	"time"
+
+	"github.com/go-nacelle/log"
+)
 
 // ProcessConfigFunc is a function used to append additional metadata
 // to an process during registration.
@@ -9,6 +13,12 @@ type ProcessConfigFunc func(*ProcessMeta)
 // WithProcessName assigns a name to an process, visible in logs.
 func WithProcessName(name string) ProcessConfigFunc {
 	return func(meta *ProcessMeta) { meta.name = name }
+}
+
+// WithProcessLoggingFields sets additional fields sent with every log message
+// from this process.
+func WithProcessLoggingFields(fields log.LogFields) ProcessConfigFunc {
+	return func(meta *ProcessMeta) { meta.loggingFields = fields }
 }
 
 // WithPriority assigns a priority to a process. A process with a lower-valued

--- a/runner.go
+++ b/runner.go
@@ -277,8 +277,7 @@ func (r *runner) inject(injectable namedInjectable) error {
 // is first modified via overlay so that the logger is tagged with the service
 // name and any additional logging fields registered to the service.
 func inject(services service.ServiceContainer, logger log.Logger, injectable namedInjectable) error {
-	// Tag the logger with the service name and any registered log fields
-	logger = logger.WithFields(log.LogFields{"service": injectable.Name()})
+	// Tag the logger with any registered log fields
 	logger = logger.WithFields(injectable.LogFields())
 
 	// Create an overlay service map replacing `logger` and `services` keys

--- a/runner.go
+++ b/runner.go
@@ -53,7 +53,7 @@ type (
 
 	namedInjectable interface {
 		Name() string
-		LoggingFields() log.LogFields
+		LogFields() log.LogFields
 		Wrapped() interface{}
 	}
 
@@ -279,7 +279,7 @@ func (r *runner) inject(injectable namedInjectable) error {
 func inject(services service.ServiceContainer, logger log.Logger, injectable namedInjectable) error {
 	// Tag the logger with the service name and any registered log fields
 	logger = logger.WithFields(log.LogFields{"service": injectable.Name()})
-	logger = logger.WithFields(injectable.LoggingFields())
+	logger = logger.WithFields(injectable.LogFields())
 
 	// Create an overlay service map replacing `logger` and `services` keys
 	serviceMap := map[string]interface{}{"logger": logger}

--- a/runner.go
+++ b/runner.go
@@ -262,7 +262,7 @@ func (r *runner) injectProcesses() bool {
 func (r *runner) inject(injectable namedInjectable) error {
 	r.logger.Info("Injecting services into %s", injectable.Name())
 
-	if err := inject(r.services, r.logger, injectable); err != nil {
+	if err := inject(injectable, r.services, r.logger); err != nil {
 		return fmt.Errorf(
 			"failed to inject services into %s (%s)",
 			injectable.Name(),
@@ -276,7 +276,7 @@ func (r *runner) inject(injectable namedInjectable) error {
 // inject will inject the given injectable with services. The service container
 // is first modified via overlay so that the logger is tagged with the service
 // name and any additional logging fields registered to the service.
-func inject(services service.ServiceContainer, logger log.Logger, injectable namedInjectable) error {
+func inject(injectable namedInjectable, services service.ServiceContainer, logger log.Logger) error {
 	// Tag the logger with any registered log fields
 	logger = logger.WithFields(injectable.LogFields())
 

--- a/watcher.go
+++ b/watcher.go
@@ -102,7 +102,7 @@ func (w *processWatcher) watchErrors() {
 			}
 
 			if err.err == nil {
-				w.logger.Info(
+				w.logger.WithFields(err.source.LogFields()).Info(
 					"%s has stopped cleanly",
 					err.source.Name(),
 				)
@@ -122,7 +122,7 @@ func (w *processWatcher) watchErrors() {
 						err.err.Error(),
 					)
 				} else {
-					w.logger.Error(
+					w.logger.WithFields(err.source.LogFields()).Error(
 						"%s returned a fatal error (%s)",
 						err.source.Name(),
 						err.err.Error(),


### PR DESCRIPTION
https://github.com/go-nacelle/service/pull/1 introduced an overlay service container so that we can "replace" services by name for downstream injections.

This updates the injection routine for initializers, parallel initializers, and processes so that additional log fields can be injected specifically into the target service.