### PR TITLE
Add context to Start, Init, Stop, and Finalize methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `Finalize` support to `Process` interface. [#5](https://github.com/go-nacelle/process/pull/5)
+- Added `WithInitializerContextFilter` and `WithProcessContextFilter`. [#5](https://github.com/go-nacelle/process/pull/5)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Finalize` support to `Process` interface. [#5](https://github.com/go-nacelle/process/pull/5)
+
+### Changed
+
+- Added context parameters to `Init`, `Start`, `Stop`, and `Finalize` methods. [#5](https://github.com/go-nacelle/process/pull/5)
+
 ## [v1.1.0] - 2020-10-03
 
 ### Added

--- a/initializer.go
+++ b/initializer.go
@@ -1,6 +1,10 @@
 package process
 
-import "github.com/go-nacelle/config"
+import (
+	"context"
+
+	"github.com/go-nacelle/config"
+)
 
 // Initializer is an interface that is called once on app
 // startup.
@@ -10,7 +14,7 @@ type Initializer interface {
 	// files from disk, connecting to a remote service,
 	// initializing shared data structures, and inserting
 	// a service into a shared service container.
-	Init(config config.Config) error
+	Init(ctx context.Context, config config.Config) error
 }
 
 // Finalizer is an optional extension of an Initializer that
@@ -21,13 +25,13 @@ type Initializer interface {
 type Finalizer interface {
 	// Finalize is called after the application has stopped
 	// all running processes.
-	Finalize() error
+	Finalize(ctx context.Context) error
 }
 
 // InitializerFunc is a non-struct version of an initializer.
-type InitializerFunc func(config config.Config) error
+type InitializerFunc func(ctx context.Context, config config.Config) error
 
 // Init calls the underlying function.
-func (f InitializerFunc) Init(config config.Config) error {
-	return f(config)
+func (f InitializerFunc) Init(ctx context.Context, config config.Config) error {
+	return f(ctx, config)
 }

--- a/initializer_meta.go
+++ b/initializer_meta.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-nacelle/log"
@@ -10,6 +11,7 @@ import (
 // private fields.
 type InitializerMeta struct {
 	Initializer
+	contextFilter   func(ctx context.Context) context.Context
 	name            string
 	logFields       log.LogFields
 	initTimeout     time.Duration
@@ -20,6 +22,14 @@ func newInitializerMeta(initializer Initializer) *InitializerMeta {
 	return &InitializerMeta{
 		Initializer: initializer,
 	}
+}
+
+func (m *InitializerMeta) FilterContext(ctx context.Context) context.Context {
+	if m.contextFilter == nil {
+		return ctx
+	}
+
+	return m.contextFilter(ctx)
 }
 
 // Name returns the name of the initializer.

--- a/initializer_options.go
+++ b/initializer_options.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-nacelle/log"
@@ -9,6 +10,11 @@ import (
 // InitializerConfigFunc is a function used to append additional
 // metadata to an initializer during registration.
 type InitializerConfigFunc func(*InitializerMeta)
+
+// WithInitializerContextFilter sets the context filter for the initializer.
+func WithInitializerContextFilter(f func(ctx context.Context) context.Context) InitializerConfigFunc {
+	return func(meta *InitializerMeta) { meta.contextFilter = f }
+}
 
 // WithInitializerName assigns a name to an initializer, visible in logs.
 func WithInitializerName(name string) InitializerConfigFunc {

--- a/mocks/initializer.go
+++ b/mocks/initializer.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"context"
 	config "github.com/go-nacelle/config"
 	process "github.com/go-nacelle/process"
 	"sync"
@@ -21,7 +22,7 @@ type MockInitializer struct {
 func NewMockInitializer() *MockInitializer {
 	return &MockInitializer{
 		InitFunc: &InitializerInitFunc{
-			defaultHook: func(config.Config) error {
+			defaultHook: func(context.Context, config.Config) error {
 				return nil
 			},
 		},
@@ -42,23 +43,23 @@ func NewMockInitializerFrom(i process.Initializer) *MockInitializer {
 // InitializerInitFunc describes the behavior when the Init method of the
 // parent MockInitializer instance is invoked.
 type InitializerInitFunc struct {
-	defaultHook func(config.Config) error
-	hooks       []func(config.Config) error
+	defaultHook func(context.Context, config.Config) error
+	hooks       []func(context.Context, config.Config) error
 	history     []InitializerInitFuncCall
 	mutex       sync.Mutex
 }
 
 // Init delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockInitializer) Init(v0 config.Config) error {
-	r0 := m.InitFunc.nextHook()(v0)
-	m.InitFunc.appendCall(InitializerInitFuncCall{v0, r0})
+func (m *MockInitializer) Init(v0 context.Context, v1 config.Config) error {
+	r0 := m.InitFunc.nextHook()(v0, v1)
+	m.InitFunc.appendCall(InitializerInitFuncCall{v0, v1, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the Init method of the
 // parent MockInitializer instance is invoked and the hook queue is empty.
-func (f *InitializerInitFunc) SetDefaultHook(hook func(config.Config) error) {
+func (f *InitializerInitFunc) SetDefaultHook(hook func(context.Context, config.Config) error) {
 	f.defaultHook = hook
 }
 
@@ -66,7 +67,7 @@ func (f *InitializerInitFunc) SetDefaultHook(hook func(config.Config) error) {
 // Init method of the parent MockInitializer instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *InitializerInitFunc) PushHook(hook func(config.Config) error) {
+func (f *InitializerInitFunc) PushHook(hook func(context.Context, config.Config) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -75,7 +76,7 @@ func (f *InitializerInitFunc) PushHook(hook func(config.Config) error) {
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *InitializerInitFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(config.Config) error {
+	f.SetDefaultHook(func(context.Context, config.Config) error {
 		return r0
 	})
 }
@@ -83,12 +84,12 @@ func (f *InitializerInitFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *InitializerInitFunc) PushReturn(r0 error) {
-	f.PushHook(func(config.Config) error {
+	f.PushHook(func(context.Context, config.Config) error {
 		return r0
 	})
 }
 
-func (f *InitializerInitFunc) nextHook() func(config.Config) error {
+func (f *InitializerInitFunc) nextHook() func(context.Context, config.Config) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -123,7 +124,10 @@ func (f *InitializerInitFunc) History() []InitializerInitFuncCall {
 type InitializerInitFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
-	Arg0 config.Config
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 config.Config
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -132,7 +136,7 @@ type InitializerInitFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c InitializerInitFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/parallel_initializer_test.go
+++ b/parallel_initializer_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestParallelInitializerInitialize(t *testing.T) {
 	pi.RegisterInitializer(i2)
 	pi.RegisterInitializer(i3)
 
-	require.Nil(t, pi.Init(nil))
+	require.Nil(t, pi.Init(context.Background(), nil))
 
 	// May initialize in any order
 	eventually(t, stringChanReceivesUnordered(init, "a", "b", "c"))
@@ -69,7 +70,7 @@ func TestParallelInitializerInitError(t *testing.T) {
 	WithInitializerName("c")(m3)
 	WithInitializerName("d")(m4)
 
-	err := pi.Init(nil)
+	err := pi.Init(context.Background(), nil)
 	require.NotNil(t, err)
 
 	expected := []errMeta{
@@ -104,7 +105,7 @@ func TestParallelInitializerFinalize(t *testing.T) {
 	pi.RegisterInitializer(i2)
 	pi.RegisterInitializer(i3)
 
-	require.Nil(t, pi.Finalize())
+	require.Nil(t, pi.Finalize(context.Background()))
 
 	// May finalize in any order
 	eventually(t, stringChanReceivesUnordered(finalize, "a", "c"))
@@ -140,7 +141,7 @@ func TestParallelInitializerFinalizeError(t *testing.T) {
 	WithInitializerName("b")(m2)
 	WithInitializerName("c")(m3)
 
-	err := pi.Finalize()
+	err := pi.Finalize(context.Background())
 	require.NotNil(t, err)
 
 	expected := []errMeta{

--- a/process.go
+++ b/process.go
@@ -1,5 +1,7 @@
 package process
 
+import "context"
+
 // Process is an interface that continually performs a behavior
 // during the life of a program. Generally, one process should
 // do a single thing. Multiple processes can be registered to
@@ -16,10 +18,10 @@ type Process interface {
 	// called (at which point a nil error should be returned).
 	// If this method is non-blocking, then the process should
 	// be registered with the WithSilentExit option.
-	Start() error
+	Start(ctx context.Context) error
 
 	// Stop informs the work being performed by the Start
 	// method to begin a graceful shutdown. This method is
 	// not expected to block until shutdown completes.
-	Stop() error
+	Stop(ctx context.Context) error
 }

--- a/process_container_test.go
+++ b/process_container_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -11,9 +12,9 @@ import (
 )
 
 func TestProcessContainerInitializers(t *testing.T) {
-	i1 := InitializerFunc(func(config.Config) error { return fmt.Errorf("a") })
-	i2 := InitializerFunc(func(config.Config) error { return fmt.Errorf("b") })
-	i3 := InitializerFunc(func(config.Config) error { return fmt.Errorf("c") })
+	i1 := InitializerFunc(func(ctx context.Context, c config.Config) error { return fmt.Errorf("a") })
+	i2 := InitializerFunc(func(ctx context.Context, c config.Config) error { return fmt.Errorf("b") })
+	i3 := InitializerFunc(func(ctx context.Context, c config.Config) error { return fmt.Errorf("c") })
 
 	c := NewProcessContainer()
 	c.RegisterInitializer(i1)
@@ -34,9 +35,9 @@ func TestProcessContainerInitializers(t *testing.T) {
 	assert.Equal(t, time.Minute*2, initializers[2].InitTimeout())
 
 	// Test inner function
-	assert.EqualError(t, initializers[0].Initializer.Init(nil), "a")
-	assert.EqualError(t, initializers[1].Initializer.Init(nil), "b")
-	assert.EqualError(t, initializers[2].Initializer.Init(nil), "c")
+	assert.EqualError(t, initializers[0].Initializer.Init(context.Background(), nil), "a")
+	assert.EqualError(t, initializers[1].Initializer.Init(context.Background(), nil), "b")
+	assert.EqualError(t, initializers[2].Initializer.Init(context.Background(), nil), "c")
 }
 
 func TestProcessContainerProcesses(t *testing.T) {
@@ -76,12 +77,12 @@ func TestProcessContainerProcesses(t *testing.T) {
 	assert.Equal(t, "b", p4[0].Name())
 
 	// Test inner function
-	assert.EqualError(t, p1[0].Process.Init(nil), "a")
-	assert.EqualError(t, p1[1].Process.Init(nil), "f")
-	assert.EqualError(t, p2[0].Process.Init(nil), "c")
-	assert.EqualError(t, p2[1].Process.Init(nil), "e")
-	assert.EqualError(t, p3[0].Process.Init(nil), "d")
-	assert.EqualError(t, p4[0].Process.Init(nil), "b")
+	assert.EqualError(t, p1[0].Process.Init(context.Background(), nil), "a")
+	assert.EqualError(t, p1[1].Process.Init(context.Background(), nil), "f")
+	assert.EqualError(t, p2[0].Process.Init(context.Background(), nil), "c")
+	assert.EqualError(t, p2[1].Process.Init(context.Background(), nil), "e")
+	assert.EqualError(t, p3[0].Process.Init(context.Background(), nil), "d")
+	assert.EqualError(t, p4[0].Process.Init(context.Background(), nil), "b")
 }
 
 //
@@ -95,6 +96,9 @@ func newInitFailProcess(name string) Process {
 	return &initFailProcess{name: name}
 }
 
-func (p *initFailProcess) Init(config config.Config) error { return fmt.Errorf("%s", p.name) }
-func (p *initFailProcess) Start() error                    { return nil }
-func (p *initFailProcess) Stop() error                     { return nil }
+func (p *initFailProcess) Init(ctx context.Context, config config.Config) error {
+	return fmt.Errorf("%s", p.name)
+}
+
+func (p *initFailProcess) Start(ctx context.Context) error { return nil }
+func (p *initFailProcess) Stop(ctx context.Context) error  { return nil }

--- a/process_meta.go
+++ b/process_meta.go
@@ -13,6 +13,7 @@ import (
 type ProcessMeta struct {
 	sync.RWMutex
 	Process
+	contextFilter   func(ctx context.Context) context.Context
 	name            string
 	logFields       log.LogFields
 	priority        int
@@ -32,6 +33,14 @@ func newProcessMeta(process Process) *ProcessMeta {
 		once:    &sync.Once{},
 		stopped: make(chan struct{}),
 	}
+}
+
+func (m *ProcessMeta) FilterContext(ctx context.Context) context.Context {
+	if m.contextFilter == nil {
+		return ctx
+	}
+
+	return m.contextFilter(ctx)
 }
 
 // Name returns the name of the process.

--- a/process_meta.go
+++ b/process_meta.go
@@ -20,6 +20,7 @@ type ProcessMeta struct {
 	initTimeout     time.Duration
 	startTimeout    time.Duration
 	shutdownTimeout time.Duration
+	finalizeTimeout time.Duration
 }
 
 func newProcessMeta(process Process) *ProcessMeta {
@@ -39,7 +40,7 @@ func (m *ProcessMeta) Name() string {
 	return m.name
 }
 
-// Logields returns logging fields registered to this process.
+// LogFields returns logging fields registered to this process.
 func (m *ProcessMeta) LogFields() log.LogFields {
 	return m.logFields
 }
@@ -60,6 +61,12 @@ func (m *ProcessMeta) Stop() (err error) {
 	})
 
 	return
+}
+
+// FinalizeTimeout returns the maximum timeout allowed for a call to
+// the Finalize function. A zero value indicates no timeout.
+func (m *ProcessMeta) FinalizeTimeout() time.Duration {
+	return m.finalizeTimeout
 }
 
 // Wrapped returns the underlying process.

--- a/process_meta.go
+++ b/process_meta.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -54,10 +55,10 @@ func (m *ProcessMeta) InitTimeout() time.Duration {
 // Stop wraps the underlying process's Stop method with a Once
 // value in order to guarantee that the Stop method will not
 // take effect multiple times.
-func (m *ProcessMeta) Stop() (err error) {
+func (m *ProcessMeta) Stop(ctx context.Context) (err error) {
 	m.once.Do(func() {
 		close(m.stopped)
-		err = m.Process.Stop()
+		err = m.Process.Stop(ctx)
 	})
 
 	return

--- a/process_meta.go
+++ b/process_meta.go
@@ -18,6 +18,7 @@ type ProcessMeta struct {
 	silentExit      bool
 	once            *sync.Once
 	stopped         chan struct{}
+	cancelCtx       func()
 	initTimeout     time.Duration
 	startTimeout    time.Duration
 	shutdownTimeout time.Duration
@@ -59,6 +60,9 @@ func (m *ProcessMeta) Stop(ctx context.Context) (err error) {
 	m.once.Do(func() {
 		close(m.stopped)
 		err = m.Process.Stop(ctx)
+		if m.cancelCtx != nil {
+			m.cancelCtx()
+		}
 	})
 
 	return

--- a/process_options.go
+++ b/process_options.go
@@ -50,3 +50,8 @@ func WithProcessStartTimeout(timeout time.Duration) ProcessConfigFunc {
 func WithProcessShutdownTimeout(timeout time.Duration) ProcessConfigFunc {
 	return func(meta *ProcessMeta) { meta.shutdownTimeout = timeout }
 }
+
+// WithProcessFinalizerTimeout sets the time limit for the finalizer.
+func WithProcessFinalizerTimeout(timeout time.Duration) ProcessConfigFunc {
+	return func(meta *ProcessMeta) { meta.finalizeTimeout = timeout }
+}

--- a/process_options.go
+++ b/process_options.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-nacelle/log"
@@ -9,6 +10,11 @@ import (
 // ProcessConfigFunc is a function used to append additional metadata
 // to an process during registration.
 type ProcessConfigFunc func(*ProcessMeta)
+
+// WithProcessContextFilter sets the context filter for the process
+func WithProcessContextFilter(f func(ctx context.Context) context.Context) ProcessConfigFunc {
+	return func(meta *ProcessMeta) { meta.contextFilter = f }
+}
 
 // WithProcessName assigns a name to an process, visible in logs.
 func WithProcessName(name string) ProcessConfigFunc {

--- a/runner.go
+++ b/runner.go
@@ -530,6 +530,8 @@ func (r *runner) startProcess(ctx context.Context, process *ProcessMeta, abandon
 	// and timeout behavior.
 
 	errChan := makeErrChan(func() error {
+		ctx, cancelCtx := context.WithCancel(ctx)
+		process.cancelCtx = cancelCtx
 		return process.Start(ctx)
 	})
 

--- a/runner.go
+++ b/runner.go
@@ -531,7 +531,7 @@ func (r *runner) startProcess(ctx context.Context, process *ProcessMeta, abandon
 
 	errChan := makeErrChan(func() error {
 		ctx, cancelCtx := context.WithCancel(ctx)
-		process.cancelCtx = cancelCtx
+		process.setCancelCtx(cancelCtx)
 		return process.Start(ctx)
 	})
 

--- a/runner.go
+++ b/runner.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -519,6 +520,7 @@ func (r *runner) getHealthDescriptions() []string {
 		descriptions = append(descriptions, fmt.Sprintf("%s", reason.Key))
 	}
 
+	sort.Strings(descriptions)
 	return descriptions
 }
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -45,7 +46,7 @@ func TestRunnerRunOrder(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -105,7 +106,7 @@ func TestRunnerEarlyExit(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -113,7 +114,7 @@ func TestRunnerEarlyExit(t *testing.T) {
 	eventually(t, stringChanReceivesOrdered(init, "a", "b"))
 	eventually(t, stringChanReceivesN(start, 2))
 
-	go p2.Stop()
+	go p2.Stop(context.Background())
 
 	// Stopping one process should shutdown the rest
 	eventually(t, stringChanReceivesUnordered(stop, "b"))
@@ -137,12 +138,12 @@ func TestRunnerSilentExit(t *testing.T) {
 	processes.RegisterProcess(p1)
 	processes.RegisterProcess(p2, WithSilentExit())
 
-	go runner.Run(nil)
+	go runner.Run(context.Background(), nil)
 
 	eventually(t, stringChanReceivesOrdered(init, "a", "b"))
 	eventually(t, stringChanReceivesN(start, 2))
 
-	go p2.Stop()
+	go p2.Stop(context.Background())
 
 	eventually(t, stringChanReceivesUnordered(stop, "b"))
 }
@@ -164,7 +165,7 @@ func TestRunnerShutdownTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -219,7 +220,7 @@ func TestRunnerProcessStartTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -262,7 +263,7 @@ func TestRunnerProcessShutdownTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -314,7 +315,7 @@ func TestRunnerInitializerInjectionError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -362,7 +363,7 @@ func TestRunnerProcessInjectionError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -401,7 +402,7 @@ func TestRunnerInitializerInitTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -439,7 +440,7 @@ func TestRunnerFinalizerFinalizeTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -486,7 +487,7 @@ func TestRunnerFinalizerError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -527,7 +528,7 @@ func TestRunnerProcessInitTimeout(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -568,7 +569,7 @@ func TestRunnerInitializerError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -621,7 +622,7 @@ func TestRunnerProcessInitError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -684,7 +685,7 @@ func TestRunnerProcessStartError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -754,7 +755,7 @@ func TestRunnerProcessStopError(t *testing.T) {
 	go func() {
 		defer close(errChan)
 
-		for err := range runner.Run(nil) {
+		for err := range runner.Run(context.Background(), nil) {
 			errChan <- err
 		}
 	}()
@@ -796,7 +797,7 @@ func newTaggedInitializer(init chan<- string, name string) *taggedInitializer {
 	}
 }
 
-func (i *taggedInitializer) Init(c config.Config) error {
+func (i *taggedInitializer) Init(ctx context.Context, c config.Config) error {
 	i.init <- i.name
 	return i.initErr
 }
@@ -820,7 +821,7 @@ func newTaggedFinalizer(init chan<- string, finalize chan<- string, name string)
 	}
 }
 
-func (i *taggedFinalizer) Finalize() error {
+func (i *taggedFinalizer) Finalize(ctx context.Context) error {
 	i.finalize <- i.name
 	return i.finalizeErr
 }
@@ -850,12 +851,12 @@ func newTaggedProcess(init, start, stop chan<- string, name string) *taggedProce
 	}
 }
 
-func (p *taggedProcess) Init(c config.Config) error {
+func (p *taggedProcess) Init(ctx context.Context, c config.Config) error {
 	p.init <- p.name
 	return p.initErr
 }
 
-func (p *taggedProcess) Start() error {
+func (p *taggedProcess) Start(ctx context.Context) error {
 	p.start <- p.name
 
 	if p.startErr != nil {
@@ -866,7 +867,7 @@ func (p *taggedProcess) Start() error {
 	return nil
 }
 
-func (p *taggedProcess) Stop() error {
+func (p *taggedProcess) Stop(ctx context.Context) error {
 	p.stop <- p.name
 	p.wait <- struct{}{}
 	return p.stopErr
@@ -885,7 +886,7 @@ func newTaggedProcessFinalizer(taggedProcess taggedProcess, finalize chan<- stri
 	}
 }
 
-func (i *taggedProcessFinalizer) Finalize() error {
+func (i *taggedProcessFinalizer) Finalize(ctx context.Context) error {
 	i.finalize <- i.name
 	return i.finalizeErr
 }
@@ -901,9 +902,9 @@ func newBlockingProcess(sync chan struct{}) *blockingProcess {
 	}
 }
 
-func (p *blockingProcess) Init(c config.Config) error { return nil }
-func (p *blockingProcess) Start() error               { close(p.sync); <-p.wait; return nil }
-func (p *blockingProcess) Stop() error                { return nil }
+func (p *blockingProcess) Init(ctx context.Context, c config.Config) error { return nil }
+func (p *blockingProcess) Start(ctx context.Context) error                 { close(p.sync); <-p.wait; return nil }
+func (p *blockingProcess) Stop(ctx context.Context) error                  { return nil }
 
 //
 //
@@ -919,7 +920,7 @@ type processWithService struct {
 func newInitializerWithService() *initializerWithService { return &initializerWithService{} }
 func newProcessWithService() *processWithService         { return &processWithService{} }
 
-func (i *initializerWithService) Init(c config.Config) error { return nil }
-func (p *processWithService) Init(c config.Config) error     { return nil }
-func (p *processWithService) Start() error                   { return nil }
-func (p *processWithService) Stop() error                    { return nil }
+func (i *initializerWithService) Init(ctx context.Context, c config.Config) error { return nil }
+func (p *processWithService) Init(ctx context.Context, c config.Config) error     { return nil }
+func (p *processWithService) Start(ctx context.Context) error                     { return nil }
+func (p *processWithService) Stop(ctx context.Context) error                      { return nil }

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"testing"
@@ -130,7 +131,7 @@ func TestWatcherShutdownTimeout(t *testing.T) {
 //
 
 func makeNamedInitializer(name string) namedInitializer {
-	initializer := InitializerFunc(func(config.Config) error {
+	initializer := InitializerFunc(func(ctx context.Context, c config.Config) error {
 		return nil
 	})
 


### PR DESCRIPTION
Closes https://github.com/go-nacelle/nacelle/issues/5.

Changes:

- Start, Init, Stop, and Finalize methods now accept a context (supplied via Runner.Run)
- Made Process optionally conform to Finalize interface
- Context for Start is canceled after calling Stop (but before calling Finalize)