### PR TITLE
Update service container use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/derision-test/glock v0.0.0-20200930205941-83423c0502c2
 	github.com/go-nacelle/log v1.1.3-0.20201221212124-3bec0a4c9b6d
-	github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c
+	github.com/go-nacelle/service v1.0.3-0.20210104035047-f3772ef7d912
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/derision-test/glock v0.0.0-20200930205941-83423c0502c2
 	github.com/go-nacelle/log v1.1.3-0.20201221212124-3bec0a4c9b6d
-	github.com/go-nacelle/service v1.0.2
+	github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/go-nacelle/log v1.1.3-0.20201221212124-3bec0a4c9b6d h1:d7uRmKDFcoe5kp
 github.com/go-nacelle/log v1.1.3-0.20201221212124-3bec0a4c9b6d/go.mod h1:LlcSgE+K/L7JWqVXGytuUcO1vwRC4eJAtoBND3DimjI=
 github.com/go-nacelle/service v1.0.2 h1:r9nb1v5GiCpCpIzRBYUYEC9Mn/Mq5Ehn/v3DlXztbtc=
 github.com/go-nacelle/service v1.0.2/go.mod h1:cxs4P9YAi9x5DezOOMajdEHcw2pvblyb44i4rU54rYU=
+github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c h1:6mmM/30OqChRJ0SlhD9CBKMlLG4PbF4ZrbWTVAAL4BQ=
+github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c/go.mod h1:cxs4P9YAi9x5DezOOMajdEHcw2pvblyb44i4rU54rYU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/go-nacelle/service v1.0.2 h1:r9nb1v5GiCpCpIzRBYUYEC9Mn/Mq5Ehn/v3DlXzt
 github.com/go-nacelle/service v1.0.2/go.mod h1:cxs4P9YAi9x5DezOOMajdEHcw2pvblyb44i4rU54rYU=
 github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c h1:6mmM/30OqChRJ0SlhD9CBKMlLG4PbF4ZrbWTVAAL4BQ=
 github.com/go-nacelle/service v1.0.3-0.20210103234805-e89ec0da266c/go.mod h1:cxs4P9YAi9x5DezOOMajdEHcw2pvblyb44i4rU54rYU=
+github.com/go-nacelle/service v1.0.3-0.20210104035047-f3772ef7d912 h1:CwhHF3zYXchqO1l1sNqDWa9fxsdAsxRPFavzKRlDf0E=
+github.com/go-nacelle/service v1.0.3-0.20210104035047-f3772ef7d912/go.mod h1:cxs4P9YAi9x5DezOOMajdEHcw2pvblyb44i4rU54rYU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/runner.go
+++ b/runner.go
@@ -34,7 +34,7 @@ type Runner interface {
 
 type runner struct {
 	processes           ProcessContainer
-	services            service.ServiceContainer
+	services            *service.Container
 	health              Health
 	watcher             *processWatcher
 	errChan             chan errMeta
@@ -74,7 +74,7 @@ type namedFinalizer interface {
 // containers.
 func NewRunner(
 	processes ProcessContainer,
-	services service.ServiceContainer,
+	services *service.Container,
 	health Health,
 	runnerConfigs ...RunnerConfigFunc,
 ) Runner {
@@ -349,13 +349,13 @@ func (r *runner) inject(injectable namedInjectable) error {
 // inject will inject the given injectable with services. The service container
 // is first modified via overlay so that the logger is tagged with the service
 // name and any additional logging fields registered to the service.
-func inject(injectable namedInjectable, services service.ServiceContainer, logger log.Logger) error {
+func inject(injectable namedInjectable, services *service.Container, logger log.Logger) error {
 	// Tag the logger with any registered log fields
 	logger = logger.WithFields(injectable.LogFields())
 
 	// Create an overlay service map replacing `logger` and `services` keys
-	serviceMap := map[string]interface{}{"logger": logger}
-	overlayServices := service.Overlay(services, serviceMap)
+	serviceMap := map[interface{}]interface{}{"logger": logger}
+	overlayServices := service.NewOverlay(services, serviceMap)
 	serviceMap["services"] = overlayServices
 
 	// Inject the services

--- a/runner_test.go
+++ b/runner_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRunnerRunOrder(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -86,7 +86,7 @@ func TestRunnerRunOrder(t *testing.T) {
 }
 
 func TestRunnerEarlyExit(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -122,7 +122,7 @@ func TestRunnerEarlyExit(t *testing.T) {
 }
 
 func TestRunnerSilentExit(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -148,7 +148,7 @@ func TestRunnerSilentExit(t *testing.T) {
 }
 
 func TestRunnerShutdownTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -181,7 +181,7 @@ func TestRunnerShutdownTimeout(t *testing.T) {
 }
 
 func TestRunnerProcessStartTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -241,7 +241,7 @@ func TestRunnerProcessStartTimeout(t *testing.T) {
 }
 
 func TestRunnerProcessShutdownTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -291,7 +291,7 @@ func TestRunnerProcessShutdownTimeout(t *testing.T) {
 }
 
 func TestRunnerInitializerInjectionError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -331,7 +331,7 @@ func TestRunnerInitializerInjectionError(t *testing.T) {
 }
 
 func TestRunnerProcessInjectionError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -383,7 +383,7 @@ func TestRunnerProcessInjectionError(t *testing.T) {
 }
 
 func TestRunnerInitializerInitTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -416,7 +416,7 @@ func TestRunnerInitializerInitTimeout(t *testing.T) {
 }
 
 func TestRunnerFinalizerFinalizeTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -462,7 +462,7 @@ func TestRunnerFinalizerFinalizeTimeout(t *testing.T) {
 }
 
 func TestRunnerFinalizerError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -507,7 +507,7 @@ func TestRunnerFinalizerError(t *testing.T) {
 }
 
 func TestRunnerProcessInitTimeout(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	clock := glock.NewMockClock()
@@ -546,7 +546,7 @@ func TestRunnerProcessInitTimeout(t *testing.T) {
 }
 
 func TestRunnerInitializerError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -592,7 +592,7 @@ func TestRunnerInitializerError(t *testing.T) {
 }
 
 func TestRunnerProcessInitError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -654,7 +654,7 @@ func TestRunnerProcessInitError(t *testing.T) {
 }
 
 func TestRunnerProcessStartError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -723,7 +723,7 @@ func TestRunnerProcessStartError(t *testing.T) {
 }
 
 func TestRunnerProcessStopError(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)
@@ -785,7 +785,7 @@ func TestRunnerProcessStopError(t *testing.T) {
 }
 
 func TestContext(t *testing.T) {
-	services := service.NewServiceContainer()
+	services := service.New()
 	processes := NewProcessContainer()
 	health := NewHealth()
 	runner := NewRunner(processes, services, health)


### PR DESCRIPTION
This update references to the service container interface as changed by https://github.com/go-nacelle/service/pull/7.