### PR TITLE
Add support for setting and retrieving a health tracker with contexts.

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -1,0 +1,18 @@
+package process
+
+import "context"
+
+type healthKeyType struct{}
+
+var healthKey = healthKeyType{}
+
+func HealthWithContext(ctx context.Context, health *Health) context.Context {
+	return context.WithValue(ctx, healthKey, health)
+}
+
+func HealthFromContext(ctx context.Context) *Health {
+	if v, ok := ctx.Value(healthKey).(*Health); ok {
+		return v
+	}
+	return nil
+}

--- a/contexts.go
+++ b/contexts.go
@@ -6,7 +6,7 @@ type healthKeyType struct{}
 
 var healthKey = healthKeyType{}
 
-func HealthWithContext(ctx context.Context, health *Health) context.Context {
+func ContextWithHealth(ctx context.Context, health *Health) context.Context {
 	return context.WithValue(ctx, healthKey, health)
 }
 

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -1,0 +1,36 @@
+package process
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthWithAndFromContext(t *testing.T) {
+	t.Run("from context without value", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Nil(t, HealthFromContext(ctx))
+	})
+	t.Run("from context that has value", func(t *testing.T) {
+		h := NewHealth()
+
+		svcKey := "some-service"
+
+		status, err := h.Register(svcKey)
+		require.NoError(t, err)
+		assert.NotNil(t, status)
+		status.Update(true)
+
+		ctx := context.Background()
+		ctx = HealthWithContext(ctx, h)
+
+		ctxHealth := HealthFromContext(ctx)
+		require.NotNil(t, ctxHealth)
+
+		ctxStatus, ok := ctxHealth.Get(svcKey)
+		require.True(t, ok)
+		assert.True(t, ctxStatus.Healthy())
+	})
+}

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -24,7 +24,7 @@ func TestHealthWithAndFromContext(t *testing.T) {
 		status.Update(true)
 
 		ctx := context.Background()
-		ctx = HealthWithContext(ctx, h)
+		ctx = ContextWithHealth(ctx, h)
 
 		ctxHealth := HealthFromContext(ctx)
 		require.NotNil(t, ctxHealth)


### PR DESCRIPTION
This adds support for getting and setting a `*Health` tracker with a context, using `HealthWithContext` to include it in a `context.Context`, and `HealthFromContext` to retrieve it.

I used a specific `HealthWith` and `HealthFrom` here because I thought there might be something else that might be worth including from this package in the context at some point and didn't want it to be ambiguous.