### PR TITLE
Add Errors method to State struct

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+# Tell sonarcloud what we're ok with duplicates in some places
+sonar.cpd.exclusions=**/*_test.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `State.Errors`.
+
 ## [v2.0.1] - 2022-10-10
 
 ### Added


### PR DESCRIPTION
This adds an `Errors` method to the `State` struct to allow us to log errors encountered at runtime from nacelle's bootstrapper.